### PR TITLE
Extract and generate list of mid-level wikiprojects

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ Use the following utility from root directory to generate machine-readable WikiP
 ```
 ./utility fetch_wikiprojects --output <output_file_name.json>
 ```
+
+## Generating mid-level category to WikiProjects mapping
+
+Use the following utility from root directory to generate a mapping of high-level topic categories to list of WikiProjects contained in them:
+
+```
+./utility trim_wikiprojects --wikiprojects wp --output outmid
+```

--- a/drafttopic/utilities/fetch_wikiprojects.py
+++ b/drafttopic/utilities/fetch_wikiprojects.py
@@ -32,7 +32,6 @@ Options:
     --output=<path>       Path to an file to write output to
                           [default: <stdout>]
     --debug               Print debug logging
-    --mid-level           Generate mid-level projects list
 """
 import datetime
 import mwapi
@@ -86,10 +85,10 @@ def main(argv=None):
         output_f = output_f + '_' + curr_time
         output_f = open(output_f, "w")
 
-    run(output_f, True)
+    run(output_f)
 
 
-def run(output, is_mid_level=False):
+def run(output):
     logger = logging.getLogger(__name__)
     parser = WikiProjectsParser(wpd_page, logger)
     wps = {}

--- a/drafttopic/utilities/fetch_wikiprojects.py
+++ b/drafttopic/utilities/fetch_wikiprojects.py
@@ -114,7 +114,7 @@ class WikiProjectsParser:
         full WikiProjects directory
         """
         dirname = self.root_dir
-        self.logger.info("Starting WikiProjects mid-level parsing")
+        print("Starting WikiProjects mid-level parsing")
         mid_level_wp = {'wikiprojects': {}}
         sections = None
         try:
@@ -154,6 +154,7 @@ class WikiProjectsParser:
             wp_topics = self.get_topics_from_wp_directory(wp_directory, path)
             mid_level_wp['wikiprojects'][project] = wp_topics
 
+        print("Finished mid-level WikiProjects parsing")
         return mid_level_wp
 
     def get_topics_from_wp_directory(self, wp, path):
@@ -193,7 +194,7 @@ class WikiProjectsParser:
         Entry point for WikiProjects parsing
         """
         dirname = self.root_dir
-        self.logger.info("Starting WikiProjects parsing")
+        print("Starting WikiProjects directory parsing")
         wp = {}
         sections = None
         try:
@@ -240,7 +241,7 @@ class WikiProjectsParser:
                     self.logger.warn("Unexpected error: ",
                                      traceback.format_exc())
                     pass
-        self.logger.info("Ended WikiProjects parsing")
+        print("Ended WikiProjects parsing")
         return wp
 
     def get_sub_categories(self, page, sections, index, level):

--- a/drafttopic/utilities/fetch_wikiprojects.py
+++ b/drafttopic/utilities/fetch_wikiprojects.py
@@ -114,7 +114,7 @@ class WikiProjectsParser:
         full WikiProjects directory
         """
         dirname = self.root_dir
-        print("Starting WikiProjects mid-level parsing")
+        self.logger.info("Starting WikiProjects mid-level parsing")
         mid_level_wp = {'wikiprojects': {}}
         sections = None
         try:
@@ -154,7 +154,7 @@ class WikiProjectsParser:
             wp_topics = self.get_topics_from_wp_directory(wp_directory, path)
             mid_level_wp['wikiprojects'][project] = wp_topics
 
-        print("Finished mid-level WikiProjects parsing")
+        self.logger.info("Finished mid-level WikiProjects parsing")
         return mid_level_wp
 
     def get_topics_from_wp_directory(self, wp, path):
@@ -194,7 +194,7 @@ class WikiProjectsParser:
         Entry point for WikiProjects parsing
         """
         dirname = self.root_dir
-        print("Starting WikiProjects directory parsing")
+        self.logger.info("Starting WikiProjects directory parsing")
         wp = {}
         sections = None
         try:

--- a/drafttopic/utilities/tests/test_fetch_wikiprojects.py
+++ b/drafttopic/utilities/tests/test_fetch_wikiprojects.py
@@ -50,6 +50,59 @@ def test_get_wikiprojects_from_section_intro_text():
     wp_topics_compare(actual_topics, topics)
 
 
+def test_get_leaf_nodes():
+    parser = WikiProjectsParser(wpd_page)
+    page_sections = parser.get_sections(
+        'Wikipedia:WikiProject_Council/Directory/Culture')
+    parsed_file = 'culture_parsed.json'
+    topics = {}
+    if is_cached(parsed_file):
+        topics = json.loads(fetch_section_text(parsed_file))
+    else:
+        topics, _ = parser.get_sub_categories(
+            'Wikipedia:WikiProject_Council/Directory/Culture',
+            page_sections, 0, 0)
+        cache_text(parsed_file, topics, logger)
+    music_topics = topics['Culture and the arts'][
+        'topics']['Performing arts']['topics']['Music']['topics']
+    actual_music_topics = [
+            "Wikipedia:WikiProject Music",
+            "Wikipedia:WikiProject Music theory",
+            "Wikipedia:WikiProject Composers",
+            "Wikipedia:WikiProject Richard Wagner",
+            "Wikipedia:WikiProject Songs",
+            "Wikipedia:WikiProject Alternative music",
+            "Wikipedia:WikiProject Black Metal",
+            "Wikipedia:WikiProject Christian music",
+            "Wikipedia:WikiProject Electronic music",
+            "Wikipedia:WikiProject Hip hop",
+            "Wikipedia:WikiProject Industrial",
+            "Wikipedia:WikiProject Metal",
+            "Wikipedia:WikiProject Post-hardcore",
+            "Wikipedia:WikiProject Progressive Rock",
+            "Wikipedia:WikiProject Punk music",
+            "Wikipedia:WikiProject Reggae",
+            "Wikipedia:WikiProject Rock music",
+            "Wikipedia:WikiProject Drum Corps",
+            "Wikipedia:WikiProject Marching band",
+            "Wikipedia:WikiProject Roots music",
+            "Wikipedia:WikiProject Australian music",
+            "Wikipedia:WikiProject Canadian music",
+            "Wikipedia:WikiProject Indian music",
+            "Wikipedia:WikiProject Musicians",
+            "Wikipedia:WikiProject Guitarists",
+            "Wikipedia:WikiProject Coldplay",
+            "Wikipedia:WikiProject Katy Perry",
+            "Wikipedia:WikiProject Madonna",
+            "Wikipedia:WikiProject Pink Floyd",
+            "Wikipedia:WikiProject Albums",
+            "Wikipedia:WikiProject Discographies",
+            "Wikipedia:WikiProject Record Production"
+        ]
+    wikiproject_topics = parser.get_leaf_nodes(music_topics)
+    eq_(wikiproject_topics, actual_music_topics)
+
+
 def test_get_sub_categories():
     parser = WikiProjectsParser(wpd_page)
     page_sections = parser.get_sections(

--- a/drafttopic/utilities/trim_wikiprojects.py
+++ b/drafttopic/utilities/trim_wikiprojects.py
@@ -1,0 +1,58 @@
+"""
+Generates a mapping of mid-level wikiprojects to list of wikiproject names
+contained in them
+{
+    'Music': ['Wikipedia: WikiProject Composer', 'Wikipedia: WikiProject Music
+    Theory'...]
+    .
+    .
+    .
+}
+
+Usage:
+    trim_wikiprojects --wikiprojects <wp> [--output=<path>] [--debug]
+    [--ignore-inactive]
+
+Options:
+    --wikiprojects        Path to wikiprojects json file
+    --output=<path>       Path to an file to write output to
+                          [default: <stdout>]
+    --debug               Print debug logging
+    --ignore-inactive     Ignore list of inactive WikiProjects
+"""
+
+import json
+import logging
+import docopt
+import sys
+from .fetch_wikiprojects import wpd_page, WikiProjectsParser
+
+
+def main(argv=None):
+    args = docopt.docopt(__doc__, argv=argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args['--debug'] else logging.WARNING,
+        format='%(asctime)s %(levelname)s:%(name)s -- %(message)s'
+    )
+    wps = args['<wp>']
+    if args['--output'] == "<stdout>":
+        output_f = sys.stdout
+    else:
+        output_f = open(args['--output'], "w")
+    run(output_f, wps)
+
+
+def run(output, wikiprojectsfile):
+    logger = logging.getLogger(__name__)
+    parser = WikiProjectsParser(wpd_page, logger)
+    wps = {}
+    try:
+        f = open(wikiprojectsfile, 'r')
+        wikiprojects = json.loads(f.read())
+        f.close()
+    except IOError as e:
+        logger.warn("Failed to read wikiprojects file")
+        return
+    wps = parser.parse_mid_level(wikiprojects)
+    output.write(json.dumps(wps, indent=4))

--- a/drafttopic/utilities/wikiprojects_common.py
+++ b/drafttopic/utilities/wikiprojects_common.py
@@ -22,10 +22,17 @@ def wptemplate2directory(template_name, wikiprojects, directory=[]):
     for key in wikiprojects:
         val = wikiprojects[key]
         if 'name' in val and val['name'] == template_name:
+            if 'root_url' in val and val['root_url'].endswith('Directory'):
+                path_new = directory[:]
+                path_new.append(key)
+                path = wptemplate2directory(
+                        template_name, val['topics'], path_new)
+                if path is not None:
+                    return path
             return directory
         if 'topics' in val:
             path_new = directory[:]
-            path_new.append(val['name'])
+            path_new.append(key)
             path = wptemplate2directory(template_name, val['topics'], path_new)
             if path is not None:
                 return path


### PR DESCRIPTION
Creates a new utility trim_wikiprojects
`./utility trim_wikiprojects --wikiprojects wp --output outmid`
This utility reads the WikiProjects directory and pulls out all the
mid-level wikiproject categories mentioned and creates a mapping of these mid-level topics to actual WikiProject topics contained in them. Will be useful fetching articles associated with each mid-level WikiProject topic.

NOTE: A flattened list of mid-level topics is created as the hierarchy on https://en.wikipedia.org/wiki/Wikipedia:WikiProject_Council/Directory isn't very well defined and I thought it best to consider all the topics at the same level. The only hierarchy exisits on some topics in "Culture and the arts" and within "Countries" in "Geography"

OUTPUT:
```
{
    "wikiprojects": {
        "Music": [
            "Wikipedia:WikiProject Music",
            "Wikipedia:WikiProject Music theory",
            "Wikipedia:WikiProject Composers",
            "Wikipedia:WikiProject Richard Wagner",
            .
            .
            .
        "Games and toys": [                                                    
            "Wikipedia:WikiProject Games",                                     
            "Wikipedia:WikiProject Board and table games",                     
            "Wikipedia:WikiProject Chess",                                     
            "Wikipedia:WikiProject Gambling",                                  
            "Wikipedia:WikiProject Go", 
         .
         .
         .
```