### PR TITLE
Add "fetch_page_wikiprojects" to label each page_id with all wikiprojects and the mid-level categories the page belongs to

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Use the following utility from root directory to label a list of page-ids with t
 ```
 
 In above, the input to the script should be a json containing a list of
-observations, each observation having a **page\_id: <page-id>** mapping.
+observations, each observation having a **page\_id: \<page-id\>** mapping.
 Additionally also pass the mid-level wikiprojects json for the script to
 generate wikiprojects to mid-level categories mapping. The script augments the
 given list with the mentioned fields, writing them to a new file specified by
-<output>
+**"output"**

--- a/README.md
+++ b/README.md
@@ -32,3 +32,18 @@ Use the following utility from root directory to generate a mapping of high-leve
 ```
 ./utility trim_wikiprojects --wikiprojects wp --output outmid
 ```
+
+## Labeling a list of page-ids with the wikiprojects and mid-level categories each page belongs to
+
+Use the following utility from root directory to label a list of page-ids with the wikiprojects and the mid-level categories the page belongs to.
+
+```
+./utility fetch_page_wikiprojects --api-host=https://en.wikipedia.org/ --input=wikiproject_page_ids.json --output=enwiki.labeled_wikiprojects.json --mid_level_wp=outmid.json --verbose
+```
+
+In above, the input to the script should be a json containing a list of
+observations, each observation having a **page\_id: <page-id>** mapping.
+Additionally also pass the mid-level wikiprojects json for the script to
+generate wikiprojects to mid-level categories mapping. The script augments the
+given list with the mentioned fields, writing them to a new file specified by
+<output>

--- a/drafttopic/utilities/fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/fetch_page_wikiprojects.py
@@ -165,7 +165,7 @@ def build_fetch_wikiprojects_info(session, mid_level_wp):
                 else:
                     if 'templates' in page_doc:
                         new_templates = extract_wikiproject_templates(
-                                page_doc['templates'])
+                            page_doc['templates'])
                         for tpl in new_templates:
                             try:
                                 rev_doc_map[pageid]['templates'].append(tpl)

--- a/drafttopic/utilities/fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/fetch_page_wikiprojects.py
@@ -1,0 +1,207 @@
+"""
+
+Annotates page_ids with all wikiproject templates
+Usage:
+    fetch_page_wikiprojects --api-host=<url>
+                            --mid_level_wp=<wp>
+                            [--input=<path>] [--output=<path>]
+                            [--debug] [--verbose]
+
+Options:
+    -h --help           Show this documentation.
+    --api-host=<url>        The hostname of a Wikipedia (MediaWiki) e.g.
+                        "https://en.wikipedia.org/"
+    --input=<path>      Path to a file contining observations
+                        labels. [default: <stdin>]
+    --output=<path>     Path to a file to write new observations
+                        (with text) out to. [default: <stdout>]
+    --verbose           Prints dots and stuff to stderr
+"""
+
+
+import json
+import logging
+import sys
+import pdb
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+from itertools import islice
+
+import mwapi
+from docopt import docopt
+from revscoring.utilities.util import dump_observation, read_observations
+from .wikiprojects_common import invert_mid_level_projects
+
+
+logger = logging.getLogger(__name__)
+
+
+mid_level_categories = "mid_level_categories"
+
+
+def main(argv=None):
+    args = docopt(__doc__, argv=argv)
+
+    logging.basicConfig(
+        level=logging.INFO if not args['--debug'] else logging.DEBUG,
+        format='%(asctime)s %(levelname)s:%(name)s -- %(message)s'
+    )
+
+    if args['--input'] == '<stdin>':
+        observations = read_observations(sys.stdin)
+    else:
+        observations = read_observations(open(args['--input']))
+
+    if args['--output'] == '<stdout>':
+        output = sys.stdout
+    else:
+        output = open(args['--output'], 'w')
+
+    session = mwapi.Session(args['--api-host'], user_agent="WikiProjects \
+                            fetch_wikiprojects utility.")
+
+    mid_level_wp = None
+    try:
+        with open(args['--mid_level_wp']) as fwp:
+            mid_level_wp = json.loads(fwp.read())
+    except:
+        logger.warn("Failed to load mid-level wikiprojects file, check and run\
+                    again")
+        pdb.set_trace()
+        sys.exit()
+    mid_level_wp = invert_mid_level_projects(mid_level_wp)
+
+    verbose = args['--verbose']
+
+    run(session, observations, output, mid_level_wp, verbose)
+
+
+def run(session, observations, output, mid_level_wp, verbose):
+
+    for ob in fetch_page_wikiprojects(session, observations, verbose=verbose):
+        dump_observation(ob, output)
+
+
+def fetch_page_wikiprojects(session, observations, mid_level_wp,
+                            verbose=False):
+    """
+    Fetches wikiproject templates associated with a page
+    :Parameters:
+        session : :class:`mwapi.Session`
+            An API session to use for querying
+        observations : `iterable`(`dict`)
+            A collection of observations to annotate
+        observations : `iterable`(`dict`)
+            A dictionary containing WikiProjects to mid-level categories
+            mappings
+        verbose : `bool`
+            Print dots and stuff
+    :Returns:
+        An `iterator` of observations augmented with the fields: templates,
+        mid_level_categories containing the requested information.
+        Note that observations that can't be found will be excluded.
+    """
+    batches = chunkify(observations, 25)
+    executor = ThreadPoolExecutor(max_workers=4)
+    _fetch_wikiprojects_info = build_fetch_wikiprojects_info(session)
+
+    for annotated_batch in executor.map(_fetch_wikiprojects_info, batches):
+        for annotated_item in annotated_batch:
+            yield annotated_item
+            if verbose:
+                sys.stderr.write(".")
+                sys.stderr.flush()
+    if verbose:
+        sys.stderr.write("\n")
+
+
+def extract_mid_level_categories(templates, inverse_mid_level_wp):
+    mid_level_set = set()
+    for tpl in templates:
+        template = tpl.replace("Template", "Wikipedia")
+        if template in inverse_mid_level_wp:
+            mid_level_set.add(inverse_mid_level_wp[template])
+    return list(mid_level_set)
+
+
+def extract_wikiproject_templates(templates):
+    """
+    Iterates over a list of templates and returns WikiProject related templates
+    from them
+    """
+    wikiprojects = []
+    for tpl in templates:
+        if tpl['title'].startswith("Template:WikiProject"):
+            wikiprojects.append(tpl['title'])
+    return wikiprojects
+
+
+def build_fetch_wikiprojects_info(session, mid_level_wp):
+
+    def _fetch_wikiprojects_info(observations):
+        doc = session.get(
+            action='query', prop='templates|info', formatversion=2,
+            tlnamespace=10, pageids=[ob['page_id'] for ob in observations],
+            continuation=True)
+        # The above returns a generator for doc, iterating over which we get
+        # results for the set of page_ids in batches. We iterate over each
+        # such batch to build the info required for each page_id, namely
+        # latest_revid and wikiproject templates
+        rev_doc_map = {}
+        for result in doc:
+            for page_doc in result['query']['pages']:
+                pageid = page_doc['pageid']
+                # seeing the page id for the first time
+                if pageid not in rev_doc_map:
+                    rev_doc_map[pageid] = \
+                        {'page_id': pageid, 'rev_id': page_doc['lastrevid'],
+                         'templates': []}
+                    if 'templates' in page_doc:
+                        rev_doc_map[pageid]['templates'] =\
+                            extract_wikiproject_templates(
+                                page_doc['templates'])
+                # some templates for this pageid were processed in previous
+                # batches, update the list with new one's
+                else:
+                    if 'templates' in page_doc:
+                        new_templates = extract_wikiproject_templates(
+                                page_doc['templates'])
+                        for tpl in new_templates:
+                            try:
+                                rev_doc_map[pageid]['templates'].append(tpl)
+                            except:
+                                logger.warn("error in processing templates for\
+                                            {0}".format(pageid))
+                                pdb.set_trace()
+        # All the templates processed for the batch, now generate mid-level
+        # categories
+        for pageid, doc in rev_doc_map.items():
+            doc[mid_level_categories] = \
+                extract_mid_level_categories(doc['templates'],
+                                             mid_level_wp['inverse_wp'])
+
+        annotated_observations = []
+        for ob in observations:
+            if ob['page_id'] not in rev_doc_map:
+                logger.warn("Could not find information for {0}".format(ob))
+            else:
+                try:
+                    rev_doc = rev_doc_map[ob['page_id']]
+                    ob['rev_id'] = rev_doc['rev_id']
+                    ob['templates'] = rev_doc['templates']
+                    ob[mid_level_categories] = rev_doc[mid_level_categories]
+                    annotated_observations.append(ob)
+                except:
+                    logger.error("Could not process {0}".format(ob))
+                    logger.error(traceback.format_exc())
+        return annotated_observations
+    return _fetch_wikiprojects_info
+
+
+def chunkify(iterable, size):
+    while True:
+        output = tuple(islice(iterable, size))
+        if output:
+            yield output
+        else:
+            break

--- a/drafttopic/utilities/fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/fetch_page_wikiprojects.py
@@ -32,7 +32,7 @@ import mwapi
 from docopt import docopt
 from revscoring.utilities.util import dump_observation, read_observations
 from .wikiprojects_common import invert_mid_level_projects,\
-                                 WIKIPROJECT_FETCH_THREADS
+        WIKIPROJECT_FETCH_THREADS
 
 
 logger = logging.getLogger(__name__)

--- a/drafttopic/utilities/fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/fetch_page_wikiprojects.py
@@ -148,7 +148,8 @@ def build_fetch_wikiprojects_info(session, mid_level_wp):
     def _fetch_wikiprojects_info(observations):
         doc = session.get(
             action='query', prop='templates|info', formatversion=2,
-            tlnamespace=10, pageids=[ob['talk_page_id'] for ob in observations],
+            tlnamespace=10, pageids=[
+                ob['talk_page_id'] for ob in observations],
             continuation=True)
         # The above returns a generator for doc, iterating over which we get
         # results for the set of page_ids in batches. We iterate over each

--- a/drafttopic/utilities/fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/fetch_page_wikiprojects.py
@@ -78,7 +78,8 @@ def main(argv=None):
 
 def run(session, observations, output, mid_level_wp, verbose):
 
-    for ob in fetch_page_wikiprojects(session, observations, verbose=verbose):
+    for ob in fetch_page_wikiprojects(session, observations,
+                                      mid_level_wp, verbose=verbose):
         dump_observation(ob, output)
 
 
@@ -103,7 +104,8 @@ def fetch_page_wikiprojects(session, observations, mid_level_wp,
     """
     batches = chunkify(observations, 25)
     executor = ThreadPoolExecutor(max_workers=4)
-    _fetch_wikiprojects_info = build_fetch_wikiprojects_info(session)
+    _fetch_wikiprojects_info = build_fetch_wikiprojects_info(session,
+                                                             mid_level_wp)
 
     for annotated_batch in executor.map(_fetch_wikiprojects_info, batches):
         for annotated_item in annotated_batch:

--- a/drafttopic/utilities/fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/fetch_page_wikiprojects.py
@@ -32,7 +32,7 @@ import mwapi
 from docopt import docopt
 from revscoring.utilities.util import dump_observation, read_observations
 from .wikiprojects_common import invert_mid_level_projects,\
-        WIKIPROJECT_FETCH_THREADS
+    WIKIPROJECT_FETCH_THREADS
 
 
 logger = logging.getLogger(__name__)

--- a/drafttopic/utilities/fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/fetch_page_wikiprojects.py
@@ -91,8 +91,6 @@ def fetch_page_wikiprojects(session, observations, mid_level_wp,
         session : :class:`mwapi.Session`
             An API session to use for querying
         observations : `iterable`(`dict`)
-            A collection of observations to annotate
-        observations : `iterable`(`dict`)
             A dictionary containing WikiProjects to mid-level categories
             mappings
         verbose : `bool`
@@ -175,7 +173,6 @@ def build_fetch_wikiprojects_info(session, mid_level_wp):
                 except:
                     logger.error("error processing templates for\
                                 {0}".format(pageid))
-                    logger.error("Templates:{0}".format(page_doc['templates']))
                     logger.error(traceback.format_exc())
         # All the templates processed for the batch, now generate mid-level
         # categories

--- a/drafttopic/utilities/fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/fetch_page_wikiprojects.py
@@ -24,6 +24,7 @@ import logging
 import sys
 import pdb
 import traceback
+from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor
 from itertools import islice
 
@@ -73,7 +74,12 @@ def main(argv=None):
 
     verbose = args['--verbose']
 
+    start_time = datetime.now()
     run(session, observations, output, mid_level_wp, verbose)
+    end_time = datetime.now()
+    time_elapsed = end_time - start_time
+    if verbose:
+        print('Time taken (hh:mm:ss.ms): {}'.format(time_elapsed))
 
 
 def run(session, observations, output, mid_level_wp, verbose):

--- a/drafttopic/utilities/tests/test_fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/tests/test_fetch_page_wikiprojects.py
@@ -1,0 +1,61 @@
+from ..fetch_page_wikiprojects import extract_mid_level_categories
+from ..fetch_page_wikiprojects import extract_wikiproject_templates
+from ..fetch_page_wikiprojects import build_fetch_wikiprojects_info
+from unittest.mock import patch
+
+
+def test_extract_mid_level_categories():
+    inverse_wp_map = {'Wikipedia:WikiProject Songs': 'Performing arts',
+                      'Wikipedia:WikiProject Science': 'Science'}
+    templates = ['Template:WikiProject Songs', 'Template:WikiProject Songs',
+                 'Template:WikiProject Science', 'Template:xyz']
+    mid_level_set = extract_mid_level_categories(templates, inverse_wp_map)
+    actual_mid_level_set = ['Performing arts', 'Science']
+    assert sorted(actual_mid_level_set) == sorted(mid_level_set)
+
+
+def test_extract_wikiproject_templates():
+    templates = [{'title': 'Template:WikiProject Songs'},
+                 {'title': 'Template:xyz'},
+                 {'title': 'Template:WikiProject Albums'},
+                 {'title': 'Template:123'}]
+    wp_templates_actual = ['Template:WikiProject Songs',
+                           'Template:WikiProject Albums']
+    wp_templates = extract_wikiproject_templates(templates)
+    assert sorted(wp_templates_actual) == sorted(wp_templates)
+
+
+mwapi_responses = [{'query': {'pages': [
+    {'pageid': 123, 'templates': [], 'lastrevid': 121},
+    {'pageid': 456, 'templates': [
+        {'title': 'Template:WikiProject abc'}, {'title': 'xyz'}],
+     'lastrevid': 111}
+]}}, {'query': {'pages': [
+    {'pageid': 123, 'templates': [
+        {'title': 'Template:WikiProject xyz'}, {'title': 'abc'}]},
+    {'pageid': 456, 'templates': []}
+]}}]
+
+
+def mwapi_generator(num_responses=2):
+    i = 0
+    while i < num_responses:
+        yield mwapi_responses[i]
+        i = i + 1
+
+
+@patch('mwapi.Session')
+def test_fetch_page_wikiprojects(mock_session):
+    mock_session.get.return_value = mwapi_generator()
+    mid_level_wp = {'inverse_wp': {}}
+    _fetch_wikiprojects_info = build_fetch_wikiprojects_info(mock_session,
+                                                             mid_level_wp)
+    obs = [{'page_id': 123}, {'page_id': 456}, {'page_id': 789}]
+    observations = _fetch_wikiprojects_info(obs)
+    actual_observations = [
+        {'page_id': 123, 'rev_id': 121, 'templates':
+         ['Template:WikiProject xyz'], 'mid_level_categories': []},
+        {'page_id': 456, 'rev_id': 111, 'templates':
+         ['Template:WikiProject abc'], 'mid_level_categories': []}
+    ]
+    assert observations == actual_observations

--- a/drafttopic/utilities/tests/test_fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/tests/test_fetch_page_wikiprojects.py
@@ -26,10 +26,10 @@ def test_extract_wikiproject_templates():
 
 
 mwapi_responses = [{'query': {'pages': [
-    {'pageid': 123, 'templates': [], 'lastrevid': 121},
+    {'pageid': 123, 'templates': [], 'lastrevid': 121, 'title': 'Page A'},
     {'pageid': 456, 'templates': [
         {'title': 'Template:WikiProject abc'}, {'title': 'xyz'}],
-     'lastrevid': 111}
+        'lastrevid': 111, 'title': 'Page B'}
 ]}}, {'query': {'pages': [
     {'pageid': 123, 'templates': [
         {'title': 'Template:WikiProject xyz'}, {'title': 'abc'}]},
@@ -50,12 +50,14 @@ def test_fetch_page_wikiprojects(mock_session):
     mid_level_wp = {'inverse_wp': {}}
     _fetch_wikiprojects_info = build_fetch_wikiprojects_info(mock_session,
                                                              mid_level_wp)
-    obs = [{'page_id': 123}, {'page_id': 456}, {'page_id': 789}]
+    obs = [{'talk_page_id': 123}, {'talk_page_id': 456}, {'talk_page_id': 789}]
     observations = _fetch_wikiprojects_info(obs)
     actual_observations = [
-        {'page_id': 123, 'rev_id': 121, 'templates':
-         ['Template:WikiProject xyz'], 'mid_level_categories': []},
-        {'page_id': 456, 'rev_id': 111, 'templates':
-         ['Template:WikiProject abc'], 'mid_level_categories': []}
+        {'talk_page_id': 123, 'rev_id': 121, 'templates':
+         ['Template:WikiProject xyz'], 'mid_level_categories': [],
+            'talk_page_title': 'Page A'},
+        {'talk_page_id': 456, 'rev_id': 111, 'templates':
+         ['Template:WikiProject abc'], 'mid_level_categories': [],
+         'talk_page_title': 'Page B'}
     ]
     assert observations == actual_observations

--- a/drafttopic/utilities/wikiprojects_common.py
+++ b/drafttopic/utilities/wikiprojects_common.py
@@ -4,6 +4,9 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+WIKIPROJECT_FETCH_THREADS = 4
+
+
 def wptemplate2directory(template_name, wikiprojects, directory=[]):
     """
     Convert a WikiProject template name to a path within the

--- a/drafttopic/utilities/wikiprojects_common.py
+++ b/drafttopic/utilities/wikiprojects_common.py
@@ -39,6 +39,17 @@ def wptemplate2directory(template_name, wikiprojects, directory=[]):
     return None
 
 
+def invert_mid_level_projects(wp):
+    # Generates inverse mappings
+    wprojects = wp['wikiprojects']
+    wp['inverse_wp'] = {}
+    for cat in wprojects:
+        wps = wprojects[cat]
+        for wikiproject in wps:
+            wp['inverse_wp'][wikiproject] = cat
+    return wp
+
+
 def is_cached(filename):
     return os.path.exists('testfiles/{}'.format(filename))
 


### PR DESCRIPTION
This adds a script **fetch_page_wikiprojects** that takes a json of pageids as well as mid-level wikiproject mappings and queries the mediawiki api to label the page ids with all wikiprojects the page belongs to as well as the mid-level categories the page is part of.
The invocation is like:
`./utility fetch_page_wikiprojects --api-host=https://en.wikipedia.org/ --input=wikiproject_page_ids.json --output=enwiki.labeled_wikiprojects.json --mid_level_wp=outmid.json --verbose`

Input:
```
{"page_id": 22921489}
{"page_id": 4493147}
{"page_id": 52854645}
.
.
```
Output:
```
{"page_id": 22921489, "rev_id": 701920493, "templates": ["Template:WikiProject Albums", "Template:WikiProject Albums/class", "Template:WikiProject Latin music"], "mid_level_categories": ["Performing arts"]}
{"page_id": 4493147, "rev_id": 805356673, "templates": ["Template:WikiProjectBannerShell", "Template:WikiProject Albums", "Template:WikiProject Albums/class", "Template:WikiProject Alternative music", "Template:WikiProject Alternative music/class", "Template:WikiProject banner shell"], "mid_level_categories": ["Performing arts"]}
```
