### PR TITLE
fetch_page_wikiprojects: Fix page processing logic

### DIFF
--- a/drafttopic/utilities/fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/fetch_page_wikiprojects.py
@@ -170,8 +170,9 @@ def build_fetch_wikiprojects_info(session, mid_level_wp):
                     if pageid not in rev_doc_map:
                         rev_doc_map[pageid] = \
                             {'talk_page_id': pageid,
-                             'rev_id': -1, 'templates': [],
-                             'talk_page_title': ''}
+                             'rev_id': page_doc.get('lastrevid', -1),
+                             'templates': [],
+                             'talk_page_title': page_doc.get('title', '')}
                     # some templates for this pageid were processed in previous
                     # batches, update the list with new one's
                     if 'lastrevid' in page_doc:

--- a/drafttopic/utilities/fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/fetch_page_wikiprojects.py
@@ -170,10 +170,16 @@ def build_fetch_wikiprojects_info(session, mid_level_wp):
                     if pageid not in rev_doc_map:
                         rev_doc_map[pageid] = \
                             {'talk_page_id': pageid,
-                             'rev_id': page_doc['lastrevid'], 'templates': [],
-                             'talk_page_title': page_doc['title']}
+                             'rev_id': -1, 'templates': [],
+                             'talk_page_title': ''}
                     # some templates for this pageid were processed in previous
                     # batches, update the list with new one's
+                    if 'lastrevid' in page_doc:
+                        rev_doc_map[pageid]['rev_id'] = \
+                            page_doc['lastrevid']
+                    if 'title' in page_doc:
+                        rev_doc_map[pageid]['talk_page_title'] = \
+                            page_doc['title']
                     if 'templates' in page_doc:
                         templates = extract_wikiproject_templates(
                             page_doc['templates'])

--- a/drafttopic/utilities/tests/test_fetch_page_wikiprojects.py
+++ b/drafttopic/utilities/tests/test_fetch_page_wikiprojects.py
@@ -26,12 +26,12 @@ def test_extract_wikiproject_templates():
 
 
 mwapi_responses = [{'query': {'pages': [
-    {'pageid': 123, 'templates': [], 'lastrevid': 121, 'title': 'Page A'},
+    {'pageid': 123, 'templates': [], 'title': 'Page A'},
     {'pageid': 456, 'templates': [
         {'title': 'Template:WikiProject abc'}, {'title': 'xyz'}],
         'lastrevid': 111, 'title': 'Page B'}
 ]}}, {'query': {'pages': [
-    {'pageid': 123, 'templates': [
+    {'pageid': 123, 'lastrevid': 121, 'templates': [
         {'title': 'Template:WikiProject xyz'}, {'title': 'abc'}]},
     {'pageid': 456, 'templates': []}
 ]}}]


### PR DESCRIPTION
If 'lastrevid' or 'title' is not returned in response, the response
processing logic errors out.
Fix this by initializing 'lastrevid' with -1 and 'title' with a blank
string and only populating them after checking their presence in
response
Modified test case to catch this error

Phab: https://phabricator.wikimedia.org/T181522