### PR TITLE
Drafttopic add GB model, tuning_report and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,5 @@ tuning_reports/enwiki.drafttopic.md: \
 	   	--observations=datasets/enwiki.labeled_wikiprojects.w_cache.json \
 	   	--verbose \
 	   	--multilabel \
-	   	--labels-config=labels-config2.yaml \
+	   	--labels-config=labels-config.yaml \
 	   	--folds=3 > $@

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ models/enwiki.drafttopic.gradient_boosting.model: \
 		drafttopic.feature_lists.wordvectors.drafttopic mid_level_categories \
 		--debug \
 	   	--labels-config=labels-config.yaml \
-	   	-p 'n_estimators=50' \
-		-p 'max_depth=3' \
+	   	-p 'n_estimators=150' \
+		-p 'max_depth=5' \
 	   	-p 'max_features="log2"' \
 	   	-p 'learning_rate=0.1' \
-	   	--folds=3 \
-	   	--model-file=models/enwiki.drafttopic.gb.model \
+	   	--folds=5 \
+	   	--model-file=models/enwiki.drafttopic.gradient_boosting.model \
 		--multilabel > $@
 
 tuning_reports/enwiki.drafttopic.md: \

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,25 @@
 datasets/enwiki.labeled_wikiprojects.json:
 	wget https://ndownloader.figshare.com/files/9828517 -qO- > $@
 
+labels-config.json: \
+	datasets/enwiki.labeled_wikiprojects.json
+	cat $< | \
+		./utility write_labels \
+		mid_level_categories > $@
+
+datasets/enwiki.labeled_wikiprojects.w_cache.json: \
+	datasets/enwiki.labeled_wikiprojects.json
+	cat $< | \
+	revscoring extract \
+	drafttopic.feature_lists.wordvectors.drafttopic \
+	--host=https://en.wikipedia.org/ \
+	--input=datasets/enwiki.labeled_wikiprojects.json > $@
+
 models/enwiki.drafttopic.gradient_boosting.model: \
 	datasets/enwiki.labeled_wikiprojects.w_cache.json
 	cat $< | \
 	revscoring cv_train revscoring.scoring.models.GradientBoosting \
-		drafttopic.feature_lists.word2vec.drafttopic mid_level_categories \
+		drafttopic.feature_lists.wordvectors.drafttopic mid_level_categories \
 		--debug \
 	   	--labels-config=labels-config.yaml \
 	   	-p 'n_estimators=50' \
@@ -16,15 +30,13 @@ models/enwiki.drafttopic.gradient_boosting.model: \
 	   	--model-file=models/enwiki.drafttopic.gb.model \
 		--multilabel > $@
 
-
 tuning_reports/enwiki.drafttopic.md: \
 	datasets/enwiki.labeled_wikiprojects.w_cache.json
 	cat $< | \
 	revscoring tune config/gradient_boosting.params.yaml \
-		drafttopic.feature_lists.word2vec.drafttopic \
+		drafttopic.feature_lists.wordvectors.drafttopic \
 	   	mid_level_categories pr_auc.macro \
 	   	--debug \
-	   	--observations=datasets/enwiki.labeled_wikiprojects.w_cache.json \
 	   	--verbose \
 	   	--multilabel \
 	   	--labels-config=labels-config.yaml \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+datasets/enwiki.labeled_wikiprojects.json:
+	wget https://ndownloader.figshare.com/files/9828517 -qO- > $@
+
+models/enwiki.drafttopic.gradient_boosting.model: \
+	datasets/enwiki.labeled_wikiprojects.w_cache.json
+	cat $< | \
+	revscoring cv_train revscoring.scoring.models.GradientBoosting \
+		drafttopic.feature_lists.word2vec.drafttopic mid_level_categories \
+		--debug \
+	   	--labels-config=labels-config.yaml \
+	   	-p 'n_estimators=50' \
+		-p 'max_depth=3' \
+	   	-p 'max_features="log2"' \
+	   	-p 'learning_rate=0.1' \
+	   	--folds=3 \
+	   	--model-file=models/enwiki.drafttopic.gb.model \
+		--multilabel > $@
+
+
+tuning_reports/enwiki.drafttopic.md: \
+	datasets/enwiki.labeled_wikiprojects.w_cache.json
+	cat $< | \
+	revscoring tune config/gradient_boosting.params.yaml \
+		drafttopic.feature_lists.word2vec.drafttopic \
+	   	mid_level_categories pr_auc.macro \
+	   	--debug \
+	   	--observations=datasets/enwiki.labeled_wikiprojects.w_cache.json \
+	   	--verbose \
+	   	--multilabel \
+	   	--labels-config=labels-config2.yaml \
+	   	--folds=3 > $@

--- a/config/gradient_boosting.params.yaml
+++ b/config/gradient_boosting.params.yaml
@@ -1,0 +1,7 @@
+GradientBoosting:
+  class: revscoring.scoring.models.GradientBoosting
+  params:
+    n_estimators: [50, ]
+    max_depth: [3, 4, 5]
+    max_features: ["log2"]
+    learning_rate: [0.01, 0.1]

--- a/tuning_reports/enwiki.drafttopic.md
+++ b/tuning_reports/enwiki.drafttopic.md
@@ -1,0 +1,30 @@
+# Model tuning report
+- Revscoring version: 2.2.0
+- Features: drafttopic.feature_lists.word2vec.drafttopic
+- Date: 2018-03-15T03:12:16.771318
+- Observations: 93392
+- Labels: ["STEM.Time", "STEM.Physics", "STEM.Space", "STEM.Mathematics", "Culture.Crafts and hobbies", "History_And_Society.Transportation", "Geography.Maps", "Culture.Internet culture", "History_And_Society.Business and economics", "Assistance.Article improvement and grading", "STEM.Biology", "STEM.Science", "STEM.Technology", "Geography.Countries", "Culture.Media", "History_And_Society.History and society", "Assistance.Contents systems", "Culture.Broadcasting", "Assistance.Maintenance", "Culture.Food and drink", "History_And_Society.Military and warfare", "Culture.Philosophy and religion", "Geography.Oceania", "Culture.Plastic arts", "History_And_Society.Education", "STEM.Engineering", "Culture.Visual arts", "STEM.Meteorology", "Culture.Language and literature", "Geography.Landforms", "Culture.Entertainment", "STEM.Medicine", "Geography.Bodies of water", "STEM.Information science", "Culture.Sports", "Geography.Europe", "History_And_Society.Politics and government", "Geography.Cities", "STEM.Geosciences", "Culture.Performing arts", "Culture.Arts", "STEM.Chemistry", "Assistance.Files"]
+- Statistic: pr_auc.macro (maximize)
+- Folds: 3
+
+# Top scoring configurations
+| model            |   pr_auc.macro | params                                                                |
+|:-----------------|---------------:|:----------------------------------------------------------------------|
+| GradientBoosting |         0.7142 | max_features="log2", max_depth=5, learning_rate=0.1, n_estimators=50  |
+| GradientBoosting |         0.6923 | max_features="log2", max_depth=4, learning_rate=0.1, n_estimators=50  |
+| GradientBoosting |         0.6647 | max_features="log2", max_depth=3, learning_rate=0.1, n_estimators=50  |
+| GradientBoosting |         0.6545 | max_features="log2", max_depth=5, learning_rate=0.01, n_estimators=50 |
+| GradientBoosting |         0.624  | max_features="log2", max_depth=4, learning_rate=0.01, n_estimators=50 |
+| GradientBoosting |         0.5869 | max_features="log2", max_depth=3, learning_rate=0.01, n_estimators=50 |
+
+# Models
+## GradientBoosting
+|   pr_auc.macro | params                                                                |
+|---------------:|:----------------------------------------------------------------------|
+|         0.7142 | max_features="log2", max_depth=5, learning_rate=0.1, n_estimators=50  |
+|         0.6923 | max_features="log2", max_depth=4, learning_rate=0.1, n_estimators=50  |
+|         0.6647 | max_features="log2", max_depth=3, learning_rate=0.1, n_estimators=50  |
+|         0.6545 | max_features="log2", max_depth=5, learning_rate=0.01, n_estimators=50 |
+|         0.624  | max_features="log2", max_depth=4, learning_rate=0.01, n_estimators=50 |
+|         0.5869 | max_features="log2", max_depth=3, learning_rate=0.01, n_estimators=50 |
+


### PR DESCRIPTION
Adds rules to makefile to fetch dataset, build model and tuning-report and gradient boosting config.

Depends on - https://github.com/wiki-ai/drafttopic/pull/20 - Script to extract and write unique labels to labels-config

See - https://phabricator.wikimedia.org/T189797