### PR TITLE
Add Fetch text and extract_from_text scripts

### DIFF
--- a/drafttopic/utilities/extract_from_text.py
+++ b/drafttopic/utilities/extract_from_text.py
@@ -1,0 +1,138 @@
+"""
+``$ drafttopic extract_from_text -h``
+::
+    Extracts dependents from a labeling doc containing text label and
+    writes a new set of labeling docs that is compatible as observations
+    for `revscoring`'s cv_train and tune utilities.
+    Input: { ... "mid-level-categories": ...,"text": ..., ... }
+    Output: { ... "mid-level-categories": ..., "cache": ..., ... }
+    Usage:
+        extract_from_text <dependent>...
+                          [--input=<path>]
+                          [--output=<path>]
+                          [--extractors=<num>]
+                          [--verbose]
+                          [--debug]
+
+    Options:
+        -h --help               Print this documentation
+        <dependent>             Classpath to a single dependent or list of
+                                dependent values to solve
+        --input=<path>          Path to a file containing observations
+                                [default: <stdin>]
+        --output=<path>         Path to a file to write new observations to
+                                [default: <stdout>]
+        --extractors=<num>      The number of parallel extractors to
+                                start [default: <cpu count>]
+        --verbose               Print dots and stuff to stderr
+        --debug                 Print debug logs
+"""
+import logging
+import sys
+from multiprocessing import Pool, cpu_count
+
+import docopt
+import yamlconf
+from revscoring import Dependent
+from revscoring.datasources import revision_oriented
+from revscoring.dependencies import solve
+from revscoring.utilities.util import dump_observation, read_observations
+
+
+def main(argv=None):
+    args = docopt.docopt(__doc__, argv=argv)
+
+    logging.basicConfig(
+        level=logging.WARNING if not args['--debug'] else logging.DEBUG,
+        format='%(asctime)s %(levelname)s:%(name)s -- %(message)s'
+    )
+
+    dependents = []
+    for dependent_path in args['<dependent>']:
+        dependent_or_list = yamlconf.import_path(dependent_path)
+        if isinstance(dependent_or_list, Dependent):
+            dependents.append(dependent_or_list)
+        else:
+            dependents.extend(dependent_or_list)
+
+    if args['--input'] == "<stdin>":
+        observations = read_observations(sys.stdin)
+    else:
+        observations = read_observations(open(args['--input']))
+
+    if args['--output'] == "<stdout>":
+        output = sys.stdout
+    else:
+        output = open(args['--output'], 'w')
+
+    if args['--extractors'] == "<cpu count>":
+        extractors = cpu_count()
+    else:
+        extractors = int(args['--extractors'])
+
+    verbose = args['--verbose']
+
+    run(observations, dependents, output, extractors, verbose)
+
+
+def run(labelings, dependents, output, extractors, verbose=False):
+    extractor_pool = Pool(processes=extractors)
+
+    extractor = LabelingDependentExtractor(dependents)
+
+    for observation in extractor_pool.imap(
+            extractor.extract_and_cache, labelings):
+        if observation is not None:
+            if verbose:
+                sys.stderr.write(".")
+                sys.stderr.flush()
+
+            dump_observation(observation, output)
+        else:
+            if verbose:
+                sys.stderr.write("-")
+                sys.stderr.flush()
+
+    if verbose:
+        sys.stderr.write("\n")
+
+
+class LabelingDependentExtractor:
+
+    def __init__(self, dependents):
+        self.dependents = dependents
+
+    def extract_and_cache(self, observation):
+        if observation['text'] is None:
+            return None
+
+        values = extract_from_text(
+            self.dependents, observation['text'],
+            cache=observation.get('cache'))
+        dependent_cache = {str(d): val
+                           for d, val in zip(self.dependents, values)}
+
+        del observation['text']
+        updated_cache = observation.get('cache', {})
+        updated_cache.update(dependent_cache)
+        observation['cache'] = updated_cache
+
+        return observation
+
+
+def extract_from_text(dependents, text, cache=None, context=None):
+    """
+    Extracts a set of values from a text an returns a cache containing just
+    those values.
+    :Parameters:
+        dependents : `list`( :class:`revscoring.Dependent` )
+            A list of dependents to extract values for
+        text : `str`
+            A text from which to extract features
+    :Returns:
+        A list of extracted feature values
+    """
+    cache = cache if cache is not None else {}
+    cache[revision_oriented.revision.text] = text
+
+    return list(solve(dependents, cache=cache, context=context))

--- a/drafttopic/utilities/fetch_text.py
+++ b/drafttopic/utilities/fetch_text.py
@@ -1,0 +1,124 @@
+"""
+    Fetches text for labelings using a MediaWiki API.
+    Usage:
+        fetch_text --api-host=<url> [--labelings=<path>] [--output=<path>]
+                                    [--verbose]
+
+    Options:
+        -h --help           Show this documentation.
+        --api-host=<url>    The hostname of a MediaWiki e.g.
+                            "https://en.wikipedia.org"
+        --labelings=<path>  Path to a containting observations with extracted
+                            labels. [default: <stdin>]
+        --output=<path>     Path to a file to write new observations
+                            (with text) out to. [default: <stdout>]
+        --verbose           Prints dots and stuff to stderr
+"""
+import re
+import sys
+
+import mwapi
+from docopt import docopt
+from revscoring.utilities.util import dump_observation, read_observations
+
+
+def main(argv=None):
+    args = docopt(__doc__, argv=argv)
+
+    if args['--labelings'] == '<stdin>':
+        labelings = read_observations(sys.stdin)
+    else:
+        labelings = read_observations(open(args['--labelings']))
+
+    if args['--output'] == '<stdout>':
+        output = sys.stdout
+    else:
+        output = open(args['--output'], 'w')
+
+    session = mwapi.Session(args['--api-host'],
+                            user_agent="Drafttopic fetch_text utility.")
+
+    verbose = args['--verbose']
+
+    run(labelings, output, session, verbose)
+
+
+def run(labelings, output, session, verbose):
+
+    for labeling in fetch_text(session, labelings, verbose=verbose):
+        if labeling['text'] is not None:
+            dump_observation(labeling, output)
+
+
+def fetch_text(session, labelings, verbose=False):
+    """
+    Fetches article text for labelings from a MediaWiki API.
+    :Parameters:
+        session : :class:`mwapi.Session`
+            An API session to use for querying
+        labelings : `iterable`(`dict`)
+            A collection of labeling events to add text to
+        verbose : `bool`
+            Print dots and stuff
+    :Returns:
+        An `iterator` of labelings augmented with 'page_id', 'rev_id' and
+        'text'.  Note that labelings of articles that aren't found will not be
+        included.
+    """
+
+    for labeling in labelings:
+        rev_doc = get_rev_from_title(session, labeling['page_title'])
+
+        if rev_doc is None:
+            if verbose:
+                sys.stderr.write("?")
+                sys.stderr.write(
+                    labeling['page_title'] + " " + labeling['timestamp'])
+                sys.stderr.flush()
+        else:
+            if verbose:
+                sys.stderr.write(".")
+                sys.stderr.flush()
+
+            labeling['rev_id'] = rev_doc.get("revid")
+            text = rev_doc.get("*")
+            if not_an_article(text):
+                labeling['text'] = None
+            else:
+                labeling['text'] = text
+
+            yield labeling
+
+    if verbose:
+        sys.stderr.write("\n")
+        sys.stderr.flush()
+
+
+def get_rev_from_title(session, page_title):
+    doc = session.get(action="query", prop="revisions", titles=page_title,
+                      rvprop=["content"], redirects=True)
+
+    try:
+        page_doc = list(doc['query']['pages'].values())[0]
+    except (KeyError, IndexError):
+        # No pages found
+        return None
+
+    try:
+        rev_doc = page_doc['revisions'][0]
+        rev_doc['page'] = {k: v for k, v in page_doc.items()
+                           if k != "revisions"}
+    except (KeyError, IndexError):
+        # No revisions matched
+        return None
+
+    return rev_doc
+
+
+REDIRECT_RE = re.compile("#redirect", re.I)
+
+
+def not_an_article(text):
+    return (text is None or
+            len(text) < 50 or
+            REDIRECT_RE.match(text))

--- a/drafttopic/utilities/fetch_text.py
+++ b/drafttopic/utilities/fetch_text.py
@@ -61,8 +61,8 @@ def fetch_text(session, labelings, verbose=False):
         verbose : `bool`
             Print dots and stuff
     :Returns:
-        An `iterator` of labelings augmented with 'page_id', 'rev_id' and
-        'text'.  Note that labelings of articles that aren't found will not be
+        An `iterator` of labelings augmented with 'text'.  Note that labelings
+        of articles that aren't found will not be
         included.
     """
 
@@ -73,14 +73,13 @@ def fetch_text(session, labelings, verbose=False):
             if verbose:
                 sys.stderr.write("?")
                 sys.stderr.write(
-                    labeling['page_title'] + " " + labeling['timestamp'])
+                    labeling['page_title'])
                 sys.stderr.flush()
         else:
             if verbose:
                 sys.stderr.write(".")
                 sys.stderr.flush()
 
-            labeling['rev_id'] = rev_doc.get("revid")
             text = rev_doc.get("*")
             if not_an_article(text):
                 labeling['text'] = None

--- a/drafttopic/utilities/fetch_text.py
+++ b/drafttopic/utilities/fetch_text.py
@@ -67,13 +67,13 @@ def fetch_text(session, labelings, verbose=False):
     """
 
     for labeling in labelings:
-        rev_doc = get_rev_from_title(session, labeling['page_title'])
+        rev_doc = get_rev_from_title(session, labeling['talk_page_title'])
 
         if rev_doc is None:
             if verbose:
                 sys.stderr.write("?")
                 sys.stderr.write(
-                    labeling['page_title'])
+                    labeling['talk_page_title'])
                 sys.stderr.flush()
         else:
             if verbose:

--- a/drafttopic/utilities/tests/test_extract_from_text.py
+++ b/drafttopic/utilities/tests/test_extract_from_text.py
@@ -1,0 +1,15 @@
+from revscoring.features import wikitext
+from ..extract_from_text import LabelingDependentExtractor
+
+labelings = [{'title': 'abc', 'text': 'hi, this is some sample text'},
+             {'title': 'xyz', 'text': 'hi, this is another sample text'}]
+
+
+def test_extractor():
+    dependents = [wikitext.revision.chars]
+    extractor = LabelingDependentExtractor(dependents)
+    key = str(dependents[0])
+    observation = extractor.extract_and_cache(labelings[0])
+    assert observation['cache'][key] == 28
+    observation = extractor.extract_and_cache(labelings[1])
+    assert observation['cache'][key] == 31

--- a/drafttopic/utilities/tests/test_fetch_text.py
+++ b/drafttopic/utilities/tests/test_fetch_text.py
@@ -1,0 +1,33 @@
+from ..fetch_text import build_fetch_text_extractor
+from unittest.mock import patch
+
+long_text = 'a' * 100
+
+mwapi_responses = [{'query': {'pages': [
+    {'title': 'A', 'ns': 0, 'revisions': [{'content': 'sometext'}]},
+    {},
+    {'title': 'B', 'ns': 0, 'revisions': [{'content': long_text}]}
+]}}]
+
+
+def mwapi_generator(num_responses=1):
+    i = 0
+    while i < num_responses:
+        yield mwapi_responses[i]
+        i = i + 1
+
+
+@patch('mwapi.Session')
+def test_get_rev_from_title(mock_session):
+    mock_session.get.return_value = mwapi_generator()
+    obs = [{'talk_page_title': 'A'},
+           {'talk_page_title': 'B'},
+           {'talk_page_title': 'C'}]
+    _fetch_text = build_fetch_text_extractor(mock_session)
+    observations = _fetch_text(obs)
+    actual_observations = [
+        {'talk_page_title': 'A', 'text': ''},
+        {'talk_page_title': 'B', 'text': long_text},
+        {'talk_page_title': 'C', 'text': ''}
+    ]
+    assert actual_observations == observations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 docopt==0.6.2
+mediawiki-utilities==0.4.18
 mwapi >= 0.5.1, < 0.5.999
 revscoring >= 2.0.1, < 2.0.999


### PR DESCRIPTION
Adds the scripts to:
* Fetch article text given the talk_page_title from the drafttopic dataset.
* Extract dependents from the fetched text per article and update cache.